### PR TITLE
Feat/use audio silence threshold

### DIFF
--- a/Runtime/PlaySafeManager.cs
+++ b/Runtime/PlaySafeManager.cs
@@ -15,8 +15,7 @@ namespace _DL.PlaySafe
 {
     public class PlaySafeManager : MonoBehaviour
     {
-        private const string PlaysafeBaseURL = "http://localhost:8787";
-        // private const string playsafeBaseURL = "https://dl-voice-ai.dogelabs.workers.dev";
+        private const string PlaysafeBaseURL = "https://dl-voice-ai.dogelabs.workers.dev";
         private const string VoiceModerationEndpoint = "/products/moderation";
         private const string ReportEndpoint = "/products/moderation";
         
@@ -838,7 +837,9 @@ namespace _DL.PlaySafe
                     _recordingIntermissionSeconds = samplingRate > 0.000001f
                         ? Mathf.Max(0, (int)((RecordingDurationSeconds / samplingRate) - RecordingDurationSeconds))
                         : int.MaxValue;
-                    _silenceThreshold = config.AudioSilenceThreshold ? config.AudioSilenceThreshold : _silenceThreshold;
+                    
+                    _silenceThreshold = config.AudioSilenceThreshold;
+                    Debug.Log($"Silence Threshold: {_silenceThreshold}");
                 }
                 else
                 {

--- a/Runtime/PlaySafeManagerResponse.cs
+++ b/Runtime/PlaySafeManagerResponse.cs
@@ -117,8 +117,8 @@ public class RemoteConfigVoiceAIData
     [JsonProperty("samplingRate")]
     public float SamplingRate { get; set; }
 
-    [JsonProperty("audioSilenceThresholdDb")]
-    public float AudioSilenceThresholdDb { get; set;}
+    [JsonProperty("audioSilenceThreshold")]
+    public float AudioSilenceThreshold { get; set;}
 
     [JsonProperty("playerStatsExpiryInDays")]
     public int PlayerStatsExpiryInDays { get; set; }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.dogelabsvr.playsafe",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "displayName": "PlaySafe",
   "description": "PlaySafe is an AI-powered suite of tools for video game moderation and character intelligence.",
   "unity": "2021.3",


### PR DESCRIPTION
1. Updated PlaySafe to accept audio silence threshold as a volume percentage
-> Ran relevant migrations
-> Deployed
-> Updated remote config for all products

2. Updated the SDK to use this silence threshold.
-> Silence threshold now comes from remote config