### PR TITLE
fix: stop recording players when they are muted

### DIFF
--- a/Runtime/PlaySafeManager.cs
+++ b/Runtime/PlaySafeManager.cs
@@ -158,8 +158,16 @@ namespace _DL.PlaySafe
 
             if (!HasMicrophonePermission())
                 return;
-
-            if (ShouldRecord())
+			
+			
+			if(_isRecording && !CanRecord())
+			{ 
+				bool shouldSendAudioForProcessing = _lastRecording.Elapsed.TotalSeconds > RecordingDurationSeconds;
+                Debug.Log($"<color=#FF0000>PlaySafeManager: Recording stopped because player muted. Time elapsed: {_lastRecording.Elapsed.TotalSeconds:F2}s. Sending for processing: {shouldSendAudioForProcessing}</color>");
+                
+				StopRecording(shouldSendAudioForProcessing);
+			}
+            else if (ShouldRecord())
             {
                 StartRecording();
             }
@@ -314,7 +322,7 @@ namespace _DL.PlaySafe
         }
 
 
-        private void StopRecording()
+        private void StopRecording(bool shouldStartCoroutine = true)
         {
             if (!_isRecording)
                 return;
@@ -342,7 +350,11 @@ namespace _DL.PlaySafe
                 Microphone.End(null);
             }
 
-            StartCoroutine(SendAudioClipForAnalysisCoroutine(_audioClipRecording));
+
+			if(shouldStartCoroutine) {
+            	StartCoroutine(SendAudioClipForAnalysisCoroutine(_audioClipRecording));
+			}
+
             _isRecording = false;
             
             Debug.Log("PlaySafeManager: Recording stopped");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.dogelabsvr.playsafe",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "displayName": "PlaySafe",
   "description": "PlaySafe is an AI-powered suite of tools for video game moderation and character intelligence.",
   "unity": "2021.3",


### PR DESCRIPTION
## Summary
Stop recording players when the mic is muted
- If the audio recording is long enough to be processed, send it over for processing
- Otherwise don't bother sending it for processing
- Bump version to `0.2.0`