### PR TITLE
build: bump version to 0.5.3 and refactor Photon voice initialization

### DIFF
--- a/Runtime/PlaySafeManager.cs
+++ b/Runtime/PlaySafeManager.cs
@@ -54,7 +54,7 @@ namespace _DL.PlaySafe
         public Action<ActionItem, DateTime> OnActionEvent { private get; set; }
 
         private float _playerSessionIntervalInSeconds = 60;
-        
+
         /// <summary>
         /// Call this method to initialize the voice AI moderation system.
         /// </summary>
@@ -211,15 +211,13 @@ namespace _DL.PlaySafe
 
         #region Photon Specific
         #if PHOTON_VOICE_DEFINED
-            // init PlaySafe once we set up photon voice; called from Photon's Recorder via SendMessage
-        public void PhotonVoiceCreated (PhotonVoiceCreatedParams voiceCreatedParams)
-        {
-            Log("Photon voice created, initializing PlaySafe");
-            Initialize();
 
+        public void SetupPhotonVoice (PhotonVoiceCreatedParams voiceCreatedParams)
+        {
             var voice = voiceCreatedParams.Voice as LocalVoiceAudioFloat;
             if (voice != null)
             {
+                Debug.Log("SetupPhotonVoice: Photon voice created");
                 channelCount = voice.Info.Channels;
                 sampleRate = voice.Info.SamplingRate;
                 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.dogelabsvr.playsafe",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "displayName": "PlaySafe",
   "description": "PlaySafe is an AI-powered suite of tools for video game moderation and character intelligence.",
   "unity": "2021.3",


### PR DESCRIPTION
## Summary
Renamed photon specific function to prevent calling `PhotonVoiceCreated` automatically in PlaySafe which can lead to timing issues when initializing Photon