### PR TITLE
build: add pause/resume recording functionality

### DIFF
--- a/Runtime/PlaySafeManager.cs
+++ b/Runtime/PlaySafeManager.cs
@@ -157,7 +157,7 @@ namespace _DL.PlaySafe
         private bool _previousCanRecordState = false;
         private Stopwatch _activeRecordingTime = new Stopwatch();
         private Stopwatch _pauseTimer = new Stopwatch();
-        private const int PauseTimeoutSeconds = 10;
+        private const int PauseTimeoutSeconds = 30;
         private const int MinimumAudioDurationSeconds = 1;
         private const int UnityMicSampleRate = 16000;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.dogelabsvr.playsafe",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "displayName": "PlaySafe",
   "description": "PlaySafe is an AI-powered suite of tools for video game moderation and character intelligence.",
   "unity": "2021.3",


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 
Implemented pause/resume recording logic to prevent players from circumventing moderation by rapidly muting/unmuting.                                                                                                                                    
Previously, muting would stop recording and discard audio clips <10s. Players could exploit this by toggling mute on/off to ensure no 10s clip ever completed.                                                                                            

Now, muting pauses the recording and unmuting resumes it. Audio accumulates across pause/resume cycles until either:                                                                                                                                      
- 10s of audio is accumulated → send for moderation                                                                                                                                                                                                       
- 10s of cumulative pause time → send whatever we have (if ≥1s)                                                                                                                                                                                           
                                                                                                                                                                                                                                                            
---                                                                                                                                                                                                                                               

## Technical breakdown                                                                                                                                                                                                                                                          - Added pause/resume state machine in Update() loop                                                                                                                                                                                                       
  -> `PauseRecording()`: stops active recording timer, starts pause timer, extracts samples (Unity Mic path)                                                                                                                                                  
  -> `ResumeRecording()`: resumes active recording timer, stops pause timer (preserves elapsed), restarts microphone (Unity Mic path)                                                                                                                         
  - Cumulative pause time tracking to close rapid toggle exploit                                                                                                                                                                                                                                                                                                                                                                               
  - Unified buffer management for Unity Mic and Photon paths                                                                                                                                                                                                