### PR TITLE
ci: auto-tag releases on package.json version change

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Release on version change
+
+# Publishes a GitHub Release whenever package.json's version changes on main. The version is owned by
+# the repo (a local hook bumps it per commit); this workflow only REACTS to it - it never edits
+# package.json, so there is no bump/release loop. Idempotent: a version that already has a release is
+# skipped, so a package.json edit that doesn't change the version publishes nothing.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - package.json
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      # Read the version and publish in one step so the (file-derived) value never crosses a step
+      # boundary. It is validated against a safe tag charset and only ever used quoted ("$TAG"), so a
+      # crafted package.json version cannot inject into the shell. No untrusted ${{ }} expansion is
+      # spliced into this script - only secrets.GITHUB_TOKEN, via env.
+      - name: Publish release if the version is new
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION="$(jq -r '.version // empty' package.json)"
+          if [ -z "$VERSION" ]; then
+            echo "::error::package.json has no version field"
+            exit 1
+          fi
+          if ! printf '%s' "$VERSION" | grep -qE '^[0-9A-Za-z][0-9A-Za-z.+_-]*$'; then
+            echo "::error::Refusing to release - version '$VERSION' is not a valid tag string"
+            exit 1
+          fi
+          TAG="v$VERSION"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists - nothing to publish."
+            exit 0
+          fi
+          gh release create "$TAG" \
+            --target "$GITHUB_SHA" \
+            --title "$TAG" \
+            --generate-notes
+          echo "Published release $TAG."


### PR DESCRIPTION
Add a GitHub Actions workflow that publishes a GitHub Release whenever package.json's version changes on main, mirroring the pattern in unity-game-tooling. The repo's local post-commit hook owns the version; this workflow only reacts to it (idempotent, no bump/release loop).